### PR TITLE
MOD-614 Refactor client.ts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@connect2ic/core",
   "author": "Mio Quispe",
   "private": false,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "files": [
     "dist",
     "providers",

--- a/packages/core/src/providers/plug-wallet.ts
+++ b/packages/core/src/providers/plug-wallet.ts
@@ -138,7 +138,7 @@ class PlugWallet implements IConnector, IWalletConnector {
           accountId: this.#ic.accountId,
         }
       }
-      return ok({ isConnected: false })
+      return ok({ isConnected: status === "connected" })
     } catch (e) {
       console.error(e)
       return err({ kind: InitError.InitFailed })


### PR DESCRIPTION
We dont need to call `isConnected()` after `init()` since `init()` should have returned the same result.
Refactoring the code to improve this.
This should mitigate the issue that we saw 2 times plug popups when init connect2ic. 